### PR TITLE
fix header license that was erroneously copy-and-pasted from other file

### DIFF
--- a/interfaces/kepware/index.js
+++ b/interfaces/kepware/index.js
@@ -1,15 +1,11 @@
 /**
- * Created by Carsten on 12/06/15.
- * Modified by Peter Som de Cerff (PCS) on 12/21/15
- *
- * Copyright (c) 2015 Carsten Strunk
+ * Copyright (c) 2018 PTC
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-//Enable this hardware interface
 var server = require('@libraries/hardwareInterfaces');
 var settings = server.loadHardwareInterface(__dirname);
 


### PR DESCRIPTION
this file was created from scratch in 2018 but someone had copied an old header into it with incorrect license information. is this ok to update?