### PR TITLE
Activate the distance tool to report permanently its distance.

### DIFF
--- a/tools/distance-slider/index.html
+++ b/tools/distance-slider/index.html
@@ -93,7 +93,9 @@
 
     realityInterface.subscribeToMatrix();
     realityInterface.addMatrixListener(function(modelView, _projection) {
-        if (!isPointerDown) { return; }
+
+      //This tool should be always on
+      //  if (!isPointerDown) { return; }
 
         // var scaleFactor = Math.abs(modelView[0]); // distance is relative to scale of frame
         var scaleFactor_IGNORED = 1; // distance is relative to scale of frame


### PR DESCRIPTION
This will make the distance slider useful. Before it only worked when you touch it.
We could lower down the frequency for calculations to 10 fps in case this takes too much resources. 

However its also only running while the tool is visible and loaded. So overall maybe not a big deal.