### PR TITLE
adds onFocus and onBlur events to spatialDraw tool

### DIFF
--- a/tools/spatialDraw/index.js
+++ b/tools/spatialDraw/index.js
@@ -132,7 +132,7 @@ iconCircles.forEach(iconCircle => {
     });
 });
 
-const isStackable = false;
+const isStackable = true;
 const areFramesOrdered = false;
 const isFullscreenFull2D = false;
 const opensWhenAdded = true;
@@ -160,6 +160,18 @@ envelope.onClose(() => {
     drawingManager.disableInteractions();
     appActive = false;
     scene.visible = false;
+});
+envelope.onBlur(() => {
+    console.log('spatialDraw envelope.onBlur');
+
+    // hide the 2D UI
+    ui.style.display = 'none';
+});
+envelope.onFocus(() => {
+    console.log('spatialDraw envelope.onFocus');
+    
+    // show the UI
+    ui.style.display = '';
 });
 
 function resetScroll() {


### PR DESCRIPTION
NOTE: in order to open multiple envelopes at the same time, `isStackable` needs to be set to true, otherwise the tool opens in "exclusiveFullscreen" mode and will be kicked out of fullscreen when another fullscreen tool opens.

TODO: Other tools will need to be updated similarly to work with the focus/blur events.

Requires https://github.com/ptcrealitylab/vuforia-spatial-edge-server/pull/761