### PR TITLE
add focus/blur listeners to video tool

### DIFF
--- a/tools/spatialVideo/index.js
+++ b/tools/spatialVideo/index.js
@@ -56,6 +56,12 @@ envelope.onClose(() => {
         videoUI.setState(VideoUIStates.EMPTY);
     }
 });
+envelope.onBlur(() => {
+    envelopeContainer.style.display = 'none'; // hide the 2D UI
+});
+envelope.onFocus(() => {
+    envelopeContainer.style.display = ''; // show the UI
+});
 
 const leaderBroadcast = () => {
     spatialInterface.writePublicData('storage', 'status', {


### PR DESCRIPTION
Hides the 2D layer of the drawing tool based on the minimize button. 3D video still plays in the userinterface until the X button is pressed.