### PR TITLE
adds new icon-foreground.svg files to tools

### DIFF
--- a/tools/spatialAnalytics/icon-foreground.svg
+++ b/tools/spatialAnalytics/icon-foreground.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 84 84" style="enable-background:new 0 0 84 84;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:4;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:3;stroke-miterlimit:10;}
+</style>
+<g>
+	<line class="st0" x1="14.6" y1="65.8" x2="69.4" y2="65.8"/>
+	<rect x="20.8" y="41.5" class="st1" width="10" height="24.3"/>
+	<rect x="36.8" y="32.1" class="st1" width="10" height="33.7"/>
+	<rect x="52.6" y="19" class="st1" width="10" height="46.9"/>
+</g>
+</svg>

--- a/tools/spatialDraw/icon-foreground.svg
+++ b/tools/spatialDraw/icon-foreground.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 84 84" style="enable-background:new 0 0 84 84;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:3;stroke-miterlimit:10;}
+</style>
+<g>
+	<polyline class="st0" points="32.7,61 29.2,64.5 18.7,65.3 19.5,54.8 22.9,51.4 	"/>
+	<line class="st0" x1="51.1" y1="23.3" x2="60.7" y2="32.9"/>
+	<path class="st0" d="M19.9,54.4l35-35c1.1-1.1,2.8-1.1,3.9,0l5.8,5.8c1.1,1.1,1.1,2.8,0,3.9l-35,35"/>
+</g>
+</svg>

--- a/tools/spatialVideo/icon-foreground.svg
+++ b/tools/spatialVideo/icon-foreground.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 84 84" style="enable-background:new 0 0 84 84;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:4;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:3;stroke-miterlimit:10;}
+</style>
+<g>
+	<path class="st0" d="M52.5,57.2c3.3,0,6.1-3.1,6.1-6.8V33.5c0-3.7-2.7-6.8-6.1-6.8H19c-3.4,0-6.1,3.1-6.1,6.8v16.9
+		c0,3.7,2.8,6.8,6.1,6.8H52.5z"/>
+	<polyline class="st1" points="57.8,48.4 71.2,52.2 71.2,31.8 57.8,35.6 	"/>
+</g>
+</svg>


### PR DESCRIPTION
Added line-only icon SVGs to the tools, so we can dynamically load them from the server from a path like: `http://192.168.0.14:8080/frames/spatialDraw/icon-foreground.svg` rather than hard-coding each tool into the userinterface