### PR TITLE
Restore all state upon focus

### DIFF
--- a/tools/spatialAnalytics/index.js
+++ b/tools/spatialAnalytics/index.js
@@ -117,6 +117,11 @@ envelope.onFocus(() => {
     focused = true;
     iconContainer.style.display = 'block';
     spatialInterface.analyticsFocus();
+    spatialInterface.analyticsSetDisplayRegion({
+        startTime,
+        endTime,
+    });
+    spatialInterface.analyticsHydrateRegionCards(knownRegionCards);
 });
 
 envelope.onBlur(() => {


### PR DESCRIPTION
Previously switching focus would not restore the display region or
region cards.