### PR TITLE
allow multiple spatial video envelopes to be open at once

### DIFF
--- a/tools/spatialVideo/index.js
+++ b/tools/spatialVideo/index.js
@@ -33,7 +33,7 @@ const randomDelay = -Math.floor(Math.random() * 100);
 launchButton.style.animationDelay = `${randomDelay}s`;
 
 const envelopeContainer = document.querySelector('#envelopeContainer');
-const envelope = new Envelope(spatialInterface, [], envelopeContainer, launchButton, false, false);
+const envelope = new Envelope(spatialInterface, [], envelopeContainer, launchButton, true, false);
 envelope.onClose(() => {
     if (videoPlayback) {
         videoPlayback.dispose();


### PR DESCRIPTION
Updates the "isStackable" param of the envelope to true to allow multiple videos to be open at once, compatible with the new multitasking UI